### PR TITLE
IAP-6 | feat: delete task completed

### DIFF
--- a/app/crud/task.py
+++ b/app/crud/task.py
@@ -22,5 +22,11 @@ def get_user_tasks(db: Session, user_id: str):
     tasks = db.query(Task).filter(Task.user_id == user_id).all()
     return tasks
 
+def delete_task(db: Session, task_id: int, user_id: str):
+    task = db.query(Task).filter(Task.id == task_id, Task.user_id == user_id).first()
+    if task:
+        db.delete(task)
+        db.commit()
+    return task
 
 

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -70,8 +70,10 @@ def auth_callback(request: Request, response: Response, db: Session = Depends(ge
         user = NewUser(cognito_id=cognito_id, username=username, email=email)
         db_user = create_user(user, db)
 
+    redirect_response = RedirectResponse(url="http://localhost:3000/")
+
     # Set the access token in a secure HTTP-only cookie
-    response.set_cookie(
+    redirect_response.set_cookie(
         key="access_token",
         value=access_token,
         httponly=True,
@@ -81,7 +83,7 @@ def auth_callback(request: Request, response: Response, db: Session = Depends(ge
     )
 
     # Return a RedirectResponse after setting the cookie
-    return RedirectResponse(url="http://localhost:3000")
+    return redirect_response
 
 
 @router.get("/me")

--- a/app/routes/task.py
+++ b/app/routes/task.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from app.db.database import get_db
 from app.utils.cognito import get_current_user_info
 from app.schemas.task import TaskCreate
-from app.crud.task import create_task, get_user_tasks 
+from app.crud.task import create_task, get_user_tasks, delete_task
 
 router = APIRouter()
 
@@ -34,3 +34,19 @@ def get_user_tasks_route(
         raise HTTPException(status_code=404, detail="No tasks found")
 
     return tasks
+
+@router.delete("/tasks/{task_id}")
+def delete_task_route(
+    task_id: int,
+    db: Session = Depends(get_db),
+    user_info: dict = Depends(get_current_user_info)
+):
+    cognito_id = user_info.get("sub")
+    if not cognito_id:
+        raise HTTPException(status_code=401, detail="User not authenticated")
+
+    task = delete_task(db=db, task_id=task_id, user_id=cognito_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    return task


### PR DESCRIPTION
## Delete Task Feature

This pull request adds the functionality for deleting tasks in the To-Do List application, at the backend level. Authenticated users can delete tasks they own with feedback from the frontend. 

### Changes Made

- **CRUD Function (`delete_task`)**: Added a function in the `task` CRUD module to handle task deletion based on the task ID and user ID, ensuring only the task owner can delete.
- **API Route**: Created a `DELETE /tasks/{task_id}` endpoint in the `task` router. This route:
  - Authenticates the user with `get_current_user_info`.
  - Validates ownership of the task.
  - Deletes the task if it belongs to the authenticated user.
  - Returns a `404` if the task is not found.

### Files Updated
- `crud/task.py`: New CRUD method to delete tasks.
- `routers/task.py`: New API route `DELETE /tasks/{task_id}`.

### Notes
This feature completes the delete task story ensuring secure task deletion with feedback for task owners.